### PR TITLE
toggle 5th bit to switch between upper and lower case letters

### DIFF
--- a/doc/03.rawInputAndOutput.md
+++ b/doc/03.rawInputAndOutput.md
@@ -17,7 +17,7 @@ to `0`. This mirrors what the <kbd>Ctrl</kbd> key does in the terminal: it
 strips the 6th and 7th bits from whatever key you press in combination with
 <kbd>Ctrl</kbd>, and sends that. The ASCII character set seems to be designed
 this way on purpose. (It is also similarly designed so that you can set and
-clear the 6th bit to switch between lowercase and uppercase.)
+clear the 5th bit to switch between lowercase and uppercase.)
 
 ## Refactor keyboard input
 


### PR DESCRIPTION
Correction - toggling the 5th (instead of the 6th) bit switches between upper and lower case letters in ascii